### PR TITLE
Tick version to 2.0, update license info

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,11 +32,11 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -47,7 +47,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - pmlandwehr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pbr" %}
-{% set version = "1.10.0" %}
-{% set checksum = "186428c270309e6fdfe2d5ab0949ab21ae5f7dea831eab96701b86bd666af39c" %}
+{% set version = "2.0.0" %}
+{% set checksum = "0ccd2db529afd070df815b1521f01401d43de03941170f8a800e7531faba265d" %}
 
 package:
   name: {{ name }}
@@ -38,8 +38,12 @@ test:
 
 about:
   home: https://launchpad.net/pbr
+  license_file: LICENSE
   license: Apache 2.0
+  license_family: Apache
   summary: Python Build Reasonableness
+  doc_url: https://docs.openstack.org/developer/pbr/
+  dev_url: https://git.openstack.org/cgit/openstack-dev/pbr
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Ticking to `2.0` - needed for more recent builds of openstack-affiliated projects.