### PR TITLE
Add explicit setuptools dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   preserve_egg_dir: true
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -29,6 +29,7 @@ requirements:
   run:
     - python >={{ python_min }}
     - pip
+    - setuptools
 
 test:
   imports:


### PR DESCRIPTION
Upstream had an implicit dependency on setuptools that only became problematic with the Python 3.13 conda package no longer depending on setuptools (and upstream Python no longer bundling setuptools), so setuptools was added as an explicit dependency for Python >=3.12 here:

https://opendev.org/openstack/pbr/commit/7cd74959d4a4857afd72f05812d4f7eb8fc449d4

(a later commit removed the Python version marker to simplify the requirement).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
